### PR TITLE
added missing dash for option --tree

### DIFF
--- a/exa.plugin.zsh
+++ b/exa.plugin.zsh
@@ -4,5 +4,5 @@ if command -v exa &> /dev/null; then
   alias ls='exa --group-directories-first --icons'
   alias ll='ls -lh --git'
   alias la='ll -a'
-  alias tree='ll -tree --level=2'
+  alias tree='ll --tree --level=2'
 fi


### PR DESCRIPTION
there was a dash missing in the options --tree for tree alias and zsh was throwing this error:
`exa: Option --time (-t) has no "ree" setting (choices: modified, changed, accessed, created)`