### PR TITLE
Add conditional statement to ll alias

### DIFF
--- a/exa.plugin.zsh
+++ b/exa.plugin.zsh
@@ -8,6 +8,15 @@ fi
 
 # Create alias override commands using 'exa'
 alias ls='exa --group-directories-first --icons'
-alias ll='ls -lh --git'
+
+# Use the --git flag if the installed version of exa supports git
+# Related to https://github.com/ogham/exa/issues/978
+if exa --version | grep -q '+git';
+then
+	alias ll='ls -lh --git'
+else
+	alias ll='ls -lh'
+fi
+
 alias la='ll -a'
 alias tree='ll --tree --level=2'


### PR DESCRIPTION
Exa does not support the git flag on all systems, namely Ubuntu. This change introduces a conditional statement in the alias declaration to only use the --git flag if git is enabled on exa.

Ref: https://github.com/ogham/exa/issues/978